### PR TITLE
patched to work with Marshmallow's method signature for makeDexElements

### DIFF
--- a/src/main/java/com/tf/thinkdroid/dex/FrameworkHack.java
+++ b/src/main/java/com/tf/thinkdroid/dex/FrameworkHack.java
@@ -143,7 +143,7 @@ public class FrameworkHack {
         Method mMakeDexElements = null;
         if (marshmallowPlus) {
             mMakeDexElements =
-                    dplClass.getDeclaredMethod("makeDexElements", List.class, File.class, List.class);
+                    dplClass.getDeclaredMethod("makePathElements", List.class, File.class, List.class);
         } else if (kitkatPlus) {
             mMakeDexElements =
                     dplClass.getDeclaredMethod("makeDexElements", ArrayList.class, File.class, ArrayList.class);

--- a/src/main/java/com/tf/thinkdroid/dex/FrameworkHack.java
+++ b/src/main/java/com/tf/thinkdroid/dex/FrameworkHack.java
@@ -26,6 +26,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.zip.ZipFile;
 
 /**
@@ -114,7 +115,7 @@ public class FrameworkHack {
     // https://android.googlesource.com/platform/libcore/+/master/libdvm/src/main/java/dalvik/system/BaseDexClassLoader.java
     // https://android.googlesource.com/platform/libcore/+/master/dalvik/src/main/java/dalvik/system/BaseDexClassLoader.java
     public static void appendDexListImplICS(ArrayList<File> jarFiles, PathClassLoader pcl, File optDir,
-                                            boolean kitkatPlus) throws Exception {
+                                            boolean kitkatPlus, boolean marshmallowPlus) throws Exception {
         if(debug) {
             Log.d(TAG, "appendDexListImplICS(" + jarFiles);
         }
@@ -140,7 +141,10 @@ public class FrameworkHack {
         Object newDexElemArray = Array.newInstance(clazzElement, orgDexCount + jarCount);
         System.arraycopy(objOrgDexElements, 0, newDexElemArray, 0, orgDexCount);
         Method mMakeDexElements = null;
-        if (kitkatPlus) {
+        if (marshmallowPlus) {
+            mMakeDexElements =
+                    dplClass.getDeclaredMethod("makeDexElements", List.class, File.class, List.class);
+        } else if (kitkatPlus) {
             mMakeDexElements =
                     dplClass.getDeclaredMethod("makeDexElements", ArrayList.class, File.class, ArrayList.class);
         } else {

--- a/src/main/java/com/thinkfree/dexdex/DexDex.java
+++ b/src/main/java/com/thinkfree/dexdex/DexDex.java
@@ -56,6 +56,8 @@ public class DexDex {
 
     private static final int SDK_INT_KITKAT = 19;
 
+    private static final int SDK_INT_MARSHMALLOW = 23;
+
     private static final int BUF_SIZE = 8 * 1024;
     public static final int PROGRESS_COMPLETE = 100;
 
@@ -257,8 +259,9 @@ public class DexDex {
                 FrameworkHack.appendDexListImplUnderICS(jarsOfDex, pcl, dexDir);
             } else { // ICS+
                 boolean kitkatPlus = Build.VERSION.SDK_INT >= SDK_INT_KITKAT;
+                boolean marshmallowPlus = Build.VERSION.SDK_INT >= SDK_INT_MARSHMALLOW;
                 ArrayList<File> jarFiles = DexDex.strings2Files(jarsOfDex);
-                FrameworkHack.appendDexListImplICS(jarFiles, pcl, dexDir, kitkatPlus);
+                FrameworkHack.appendDexListImplICS(jarFiles, pcl, dexDir, kitkatPlus, marshmallowPlus);
             }
             // update theAppended if succeeded to prevent duplicated classpath entry
             for (String jarName : names) {


### PR DESCRIPTION
This will now work with Marshmallow.

I know Android added official multidex support, but there's a few organizations out there using this that probably won't update their apps unless it's as easy as a library update and recompile.

Marshmallow introduced a change that affects the makeDexElements method signature. Basically, it changed ArrayList references to just List for that method's arguments.

You can see this change here: https://android.googlesource.com/platform/libcore/+/7694b783f48e2cc57928b61c84fd90311cb0c35a%5E%21/#F1
